### PR TITLE
fix: use `additional_contexts` to force cli service image to build first when using buildkit + bake

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       dockerfile: lagoon/nginx.dockerfile
       args:
         CLI_IMAGE: *cli-image # Inject the name of the cli image
+      additional_contexts:
+        cli: 'service:cli' # Ensure cli is built first
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.persistent: /app/web/sites/default/files/ # define where the persistent storage should be mounted too
@@ -59,7 +61,7 @@ services:
       - "8080" # exposes the port 8080 with a random local port, find it with `docker-compose port nginx 8080`
     << : [*default-volumes, *default-user]
     depends_on:
-      - cli # basically just tells docker-compose to build the cli first
+     - cli
     environment:
       << : *default-environment # loads the defined environment variables from the top
       LAGOON_LOCALDEV_URL: *default-url
@@ -73,6 +75,8 @@ services:
       dockerfile: lagoon/php.dockerfile
       args:
         CLI_IMAGE: *cli-image
+      additional_contexts:
+        cli: 'service:cli' # Ensure cli is built first
     labels:
       lagoon.type: nginx-php-persistent
       lagoon.name: nginx # we want this service be part of the nginx pod in Lagoon
@@ -80,7 +84,7 @@ services:
       lando.type: php-fpm
     << : [*default-volumes, *default-user]
     depends_on:
-      - cli # basically just tells docker-compose to build the cli first
+      - cli
     environment:
       << : *default-environment # loads the defined environment variables from the top
 


### PR DESCRIPTION
Starting in docker compose version 2.37, `bake` was enabled as the default image builder. This change re-introduced an error we saw when `buildkit` became the default image builder, where all images are built in parallel, even if some images depend on others.

The error being thrown is:
> target nginx: failed to solve: drupal-base-cli: failed to resolve source metadata for docker.io/library/drupal-base-cli:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed

This was eventually fixed with `compose` +  `buildkit`, but even though dozens of issues have been opened against `compose` + `bake`, the maintainers are adamant about not "fixing" it this time. A number of solutions are available, including switching to multi-stage builds, but I think the most "minimal" change is to switch from `depends_on` (works in compose v1 and compose v2 with buildkit) to `additional_contexts`. The largest downside is that it requires `buildkit` (but doesn't require `bake`).

Before this PR

| cmd | status|
|:-------|---------:|
| docker-compose build (v1) | works |
| docker compose build (v2) | works |
| DOCKER_BUILDKIT=0 docker compose build | works |
| docker compose build (>=2.37) | breaks |
| COMPOSE_BAKE=false docker compose build (>= 2.37) | works |

After this PR
| cmd | status|
|:-------|---------:|
| docker-compose build (v1) | breaks |
| docker compose build (v2) | works |
| DOCKER_BUILDKIT=0 docker compose build | breaks |
| docker compose build (>=2.37) | works |
| COMPOSE_BAKE=false docker compose build (>= 2.37) | works |